### PR TITLE
Fix RSS icon

### DIFF
--- a/themes/blackburn/layouts/partials/social.html
+++ b/themes/blackburn/layouts/partials/social.html
@@ -4,7 +4,7 @@
     {{ if .OutputFormats.Get "RSS" }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'><i
-          class="fas fa-rss"></i>RSS</a>
+          class="fa fa-rss fa-fw"></i>RSS</a>
     </li>
     {{ end }}
 


### PR DESCRIPTION
Hey Ann! 

I found your site linked in your email signature and noticed the RSS icon was busted:

**Before**: 
![Screen Shot 2020-07-11 at 2 16 33 PM](https://user-images.githubusercontent.com/75876/87234030-f7929e00-c381-11ea-9137-b07e734374e0.png)


**After**: 
![Screen Shot 2020-07-11 at 2 22 27 PM](https://user-images.githubusercontent.com/75876/87234037-fbbebb80-c381-11ea-95c5-67cb6faad86e.png)

ps
It looks like your theme has deviated from [yoshiharuyamashita/blackburn](https://github.com/yoshiharuyamashita/blackburn)   so I didn't open a PR there.

pps 
❤️  Hugo! 